### PR TITLE
Fixes VSTS plugin when open web page with spaces in project name

### DIFF
--- a/src/AnyStatus.Plugins.Tests/VSTS/VstsBuildTests.cs
+++ b/src/AnyStatus.Plugins.Tests/VSTS/VstsBuildTests.cs
@@ -33,6 +33,29 @@ namespace AnyStatus.Plugins.Tests
         }
 
         [TestMethod]
+        public async Task OpenVstsBuildWebPageWithSpacesInProjectName()
+        {
+            var ps = Substitute.For<IProcessStarter>();
+
+            var build = new VSTSBuild_v1
+            {
+                Account = "account",
+                Project = "project with spaces",
+                DefinitionId = 1
+            };
+
+            var request = OpenWebPageRequest.Create(build);
+
+            var handler = new OpenVstsBuildPage(ps);
+
+            await handler.Handle(request, CancellationToken.None);
+
+            var expected = "https://account.visualstudio.com/project%20with%20spaces/_build/index?definitionId=1&_a=completed";
+
+            ps.Received().Start(expected);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(VstsClientException))]
         public async Task VstsBuildHealthCheckTest()
         {

--- a/src/AnyStatus.Plugins/Widgets/VSTS/Build/VstsBuild_v1.cs
+++ b/src/AnyStatus.Plugins/Widgets/VSTS/Build/VstsBuild_v1.cs
@@ -1,6 +1,8 @@
-﻿using AnyStatus.API;
+﻿using System;
+using AnyStatus.API;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Net;
 using System.Xml.Serialization;
 using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
 
@@ -26,7 +28,7 @@ namespace AnyStatus
         [Browsable(false)]
         public long? DefinitionId { get; set; }
 
-        public string URL => $"https://{Account}.visualstudio.com/{Project}/_build/index?definitionId={DefinitionId}&_a=completed";
+        public string URL => $"https://{Account}.visualstudio.com/{Uri.EscapeDataString(Project)}/_build/index?definitionId={DefinitionId}&_a=completed";
 
         public override object Clone()
         {


### PR DESCRIPTION
Selecting "Open in Browser" on the VSTS plugin fails "Oops! An error occured...." when there is a space in the project name. Having a project with spaces in the name is allowed in VSTS. This pull request fixes this behavior.