### PR TITLE
 Implemented: CPU usage of specific process #123

### DIFF
--- a/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
+++ b/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -90,6 +90,8 @@
     <Compile Include="Widgets\HealthChecks\WindowsService\WindowsServiceNameEditor.cs" />
     <Compile Include="Widgets\Metrics\Battery\Battery.cs" />
     <Compile Include="Widgets\Metrics\Battery\BatteryStatusQuery.cs" />
+    <Compile Include="Widgets\Metrics\CPU\ProcessUsage\CpuProcessUsage.cs" />
+    <Compile Include="Widgets\Metrics\CPU\ProcessUsage\CpuProcessUsageQuery.cs" />
     <Compile Include="Widgets\Metrics\CPU\Usage\CpuUsageQuery.cs" />
     <Compile Include="Widgets\Custom\BatchFile\BatchFileRunner.cs" />
     <Compile Include="Widgets\Custom\NET\CodeRunner.cs" />

--- a/src/AnyStatus.Plugins/Widgets/HealthChecks/Pingdom/Pingdom.cs
+++ b/src/AnyStatus.Plugins/Widgets/HealthChecks/Pingdom/Pingdom.cs
@@ -7,7 +7,7 @@ namespace AnyStatus
 {
     [DisplayName("Pingdom")]
     [DisplayColumn("Health Checks")]
-    [Description("Single or multiple Pingdon health checks.")]
+    [Description("Single or multiple Pingdom health checks.")]
     public class Pingdom : Widget, IHealthCheck, ISchedulable
     {
         private const string Category = "Pingdom";

--- a/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsage.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsage.cs
@@ -1,0 +1,32 @@
+﻿using AnyStatus.API;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace AnyStatus
+{
+    [DisplayColumn("Metrics")]
+    [DisplayName("Process CPU Usage")]
+    [Description("Shows the percentage of CPU usage for a single process")]
+    public class CpuProcessUsage : Sparkline, ISchedulable
+    {
+        public CpuProcessUsage()
+        {
+            Symbol = "%";
+            Interval = 10;
+            Units = IntervalUnits.Seconds;
+            Name = "CPU Process Usage";
+            MaxValue = 100;
+        }
+
+        [Category("Process CPU Usage")]
+        [DisplayName("Machine Name")]
+        [Description("Optional. Leave blank for local computer.")]
+        public string MachineName { get; set; }
+
+        [Required]
+        [Category("Process CPU Usage")]
+        [DisplayName("Process Name")]
+        [Description("Usually the file name without extension")]
+        public string ProcessName { get; set; }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsageQuery.cs
@@ -18,12 +18,6 @@ namespace AnyStatus
             request.DataContext.State = State.Ok;
         }
 
-        /// <exception cref="System.InvalidOperationException">Ignore.</exception>
-        /// <exception cref="System.ComponentModel.Win32Exception">Ignore.</exception>
-        /// <exception cref="System.UnauthorizedAccessException">Ignore.</exception>
-        /// <exception cref="System.InvalidOperationException">Ignore.</exception>
-        /// <exception cref="System.ComponentModel.Win32Exception">Ignore.</exception>
-        /// <exception cref="System.UnauthorizedAccessException">Ignore.</exception>
         private static async Task<int> GetCpuUsageAsync(string machineName, string processName)
         {
             using (var counter = string.IsNullOrWhiteSpace(machineName)

--- a/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/CPU/ProcessUsage/CpuProcessUsageQuery.cs
@@ -1,0 +1,41 @@
+﻿using AnyStatus.API;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AnyStatus
+{
+    public class CpuProcessUsageQuery : IMetricQuery<CpuProcessUsage>
+    {
+        private const string CategoryName = "Process";
+        private const string CounterName = "% Processor Time";
+
+        [DebuggerStepThrough]
+        public async Task Handle(MetricQueryRequest<CpuProcessUsage> request, CancellationToken cancellationToken)
+        {
+            request.DataContext.Value = await GetCpuUsageAsync(request.DataContext.MachineName, request.DataContext.ProcessName).ConfigureAwait(false);
+
+            request.DataContext.State = State.Ok;
+        }
+
+        /// <exception cref="System.InvalidOperationException">Ignore.</exception>
+        /// <exception cref="System.ComponentModel.Win32Exception">Ignore.</exception>
+        /// <exception cref="System.UnauthorizedAccessException">Ignore.</exception>
+        /// <exception cref="System.InvalidOperationException">Ignore.</exception>
+        /// <exception cref="System.ComponentModel.Win32Exception">Ignore.</exception>
+        /// <exception cref="System.UnauthorizedAccessException">Ignore.</exception>
+        private static async Task<int> GetCpuUsageAsync(string machineName, string processName)
+        {
+            using (var counter = string.IsNullOrWhiteSpace(machineName)
+                ? new System.Diagnostics.PerformanceCounter(CategoryName, CounterName, processName)
+                : new System.Diagnostics.PerformanceCounter(CategoryName, CounterName, processName, machineName))
+            {
+                counter.NextValue();
+
+                await Task.Delay(1000).ConfigureAwait(false);
+
+                return (int)counter.NextValue();
+            }
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/Metrics/CPU/Usage/CpuUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/CPU/Usage/CpuUsageQuery.cs
@@ -7,6 +7,10 @@ namespace AnyStatus
 {
     public class CpuUsageQuery : IMetricQuery<CpuUsage>
     {
+        private const string CategoryName = "Processor";
+        private const string CounterName = "% Processor Time";
+        private const string InstanceName = "_Total";
+
         [DebuggerStepThrough]
         public async Task Handle(MetricQueryRequest<CpuUsage> request, CancellationToken cancellationToken)
         {
@@ -17,15 +21,16 @@ namespace AnyStatus
 
         private static async Task<int> GetCpuUsageAsync(string machineName)
         {
-            var counter = string.IsNullOrWhiteSpace(machineName)
-                ? new System.Diagnostics.PerformanceCounter("Processor", "% Processor Time", "_Total")
-                : new System.Diagnostics.PerformanceCounter("Processor", "% Processor Time", "_Total", machineName);
+            using (var counter = string.IsNullOrWhiteSpace(machineName)
+                ? new System.Diagnostics.PerformanceCounter(CategoryName, CounterName, InstanceName)
+                : new System.Diagnostics.PerformanceCounter(CategoryName, CounterName, InstanceName, machineName))
+            {
+                counter.NextValue();
 
-            counter.NextValue();
+                await Task.Delay(1000).ConfigureAwait(false);
 
-            await Task.Delay(1000).ConfigureAwait(false);
-
-            return (int)counter.NextValue();
+                return (int)counter.NextValue();
+            }
         }
     }
 }


### PR DESCRIPTION
Created a new plugin which monitors the CPU usage of a single process.

I couldn't figure out how to set the order of the plugins in the Add Widget dialog so it currently sits about 2 thirds down the list on my machine - I think ideally it should sit directly beneath the plugin which monitors the total CPU usage