### PR TITLE
Feature: RAM Usage #134

### DIFF
--- a/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
+++ b/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
@@ -100,6 +100,9 @@
     <Compile Include="Widgets\Metrics\PerformanceCounters\BasePerformanceCounterQuery.cs" />
     <Compile Include="Widgets\Metrics\PerformanceCounters\Threads.cs" />
     <Compile Include="Widgets\Metrics\PerformanceCounters\Processes.cs" />
+    <Compile Include="Widgets\Metrics\RAM\Usage\RamInformation.cs" />
+    <Compile Include="Widgets\Metrics\RAM\Usage\RamUsage.cs" />
+    <Compile Include="Widgets\Metrics\RAM\Usage\RamUsageQuery.cs" />
     <Compile Include="Widgets\Metrics\SqlServer\ScalarQuery\SqlScalarQueryHandler.cs" />
     <Compile Include="Widgets\DevOps\GitHub\Issue\v1\GitHubIssueState.cs" />
     <Compile Include="Widgets\DevOps\GitHub\Issue\v1\GitHubIssueStateCheck.cs" />

--- a/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamInformation.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamInformation.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace AnyStatus
+{
+    public static class RamInformation
+    {
+        private const string PsapiDLL = "psapi.dll";
+        private const int MegabyteFactor = 1024 * 1024;
+        private static readonly int piSize = Marshal.SizeOf(new PerformanceInformation());
+
+        [DllImport(PsapiDLL, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetPerformanceInfo([Out] out PerformanceInformation PerformanceInformation, [In] int Size);
+
+        public static decimal GetPercentageOfMemoryInUseMiB()
+        {
+            if (!GetPerformanceInfo(out PerformanceInformation pi, piSize))
+            {
+                return -1;
+            }
+
+            long pageSize = pi.PageSize.ToInt64();
+
+            long availableMemory = pi.PhysicalAvailable.ToInt64() * pageSize / MegabyteFactor;
+            long totalMemory = pi.PhysicalTotal.ToInt64() * pageSize / MegabyteFactor;
+            long usedMemory = totalMemory - availableMemory;
+
+            return (decimal)usedMemory / totalMemory * 100;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PerformanceInformation
+        {
+            public int Size;
+            public IntPtr CommitTotal;
+            public IntPtr CommitLimit;
+            public IntPtr CommitPeak;
+            public IntPtr PhysicalTotal;
+            public IntPtr PhysicalAvailable;
+            public IntPtr SystemCache;
+            public IntPtr KernelTotal;
+            public IntPtr KernelPaged;
+            public IntPtr KernelNonPaged;
+            public IntPtr PageSize;
+            public int HandlesCount;
+            public int ProcessCount;
+            public int ThreadCount;
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamUsage.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamUsage.cs
@@ -1,0 +1,21 @@
+﻿using AnyStatus.API;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace AnyStatus
+{
+    [DisplayColumn("Metrics")]
+    [DisplayName("RAM Usage")]
+    [Description("Shows the percentage of RAM usage for the local machine")]
+    public class RamUsage : Sparkline, ISchedulable
+    {
+        public RamUsage()
+        {
+            Symbol = "%";
+            Interval = 10;
+            Units = IntervalUnits.Seconds;
+            Name = "RAM Usage";
+            MaxValue = 100;
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/RAM/Usage/RamUsageQuery.cs
@@ -1,0 +1,20 @@
+﻿using AnyStatus.API;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AnyStatus
+{
+    public class RamUsageQuery : IMetricQuery<RamUsage>
+    {
+        [DebuggerStepThrough]
+        public async Task Handle(MetricQueryRequest<RamUsage> request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(1000).ConfigureAwait(false);
+
+            request.DataContext.Value = (int)RamInformation.GetPercentageOfMemoryInUseMiB();
+
+            request.DataContext.State = request.DataContext.Value == -1 ? State.Error : State.Ok;
+        }
+    }
+}


### PR DESCRIPTION
Implemented a 'RAM Percentage Used' metric for AnyStatus/Support#134

Decided not to use the `System.Diagnostics.PerformanceCounter` class because this includes the pager file in it's calculations which makes them inaccurate.

![](https://puu.sh/DBFZz/1da86b3931.png)

As you can see in this image, the `PerformanceCounter` would use the 19GB shown towards the bottom of my screen when I only have 16GB.

This does unfortunately mean the plugin only works for the local machine - but it's accurate. I'd be happy to re-work it to use the `PerformanceCounter` if it's a higher priority to be able to monitor other machines, but for my machine it was out by a good 10%.