### PR TITLE
#137

### DIFF
--- a/src/AnyStatus.Plugins.Tests/Widgets/SystemInformationTests.cs
+++ b/src/AnyStatus.Plugins.Tests/Widgets/SystemInformationTests.cs
@@ -1,6 +1,8 @@
 ﻿using AnyStatus.API;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -126,7 +128,7 @@ namespace AnyStatus.Plugins.Tests.Widgets
         }
 
         [TestMethod]
-        public void FileExistsTest()
+        public async Task FileExistsTest()
         {
             var widget = new FileExists
             {
@@ -135,13 +137,13 @@ namespace AnyStatus.Plugins.Tests.Widgets
 
             var request = HealthCheckRequest.Create(widget);
 
-            _ = new FileExistsCheck().Handle(request, CancellationToken.None).ConfigureAwait(false);
+            await new FileExistsCheck().Handle(request, CancellationToken.None).ConfigureAwait(false);
 
             Assert.AreEqual(State.Ok, widget.State);
         }
 
         [TestMethod]
-        public void FileNotExistsTest()
+        public async Task FileNotExistsTest()
         {
             var widget = new FileExists
             {
@@ -150,7 +152,83 @@ namespace AnyStatus.Plugins.Tests.Widgets
 
             var request = HealthCheckRequest.Create(widget);
 
-            _ = new FileExistsCheck().Handle(request, CancellationToken.None).ConfigureAwait(false);
+            await new FileExistsCheck().Handle(request, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(State.Failed, widget.State);
+        }
+
+        [TestMethod]
+        public async Task LogicalDriveUsage_PercentageUsed_Test()
+        {
+            var drive = DriveInfo.GetDrives().First();
+
+            var widget = new LogicalDriveUsage
+            {
+                Drive = drive.Name,
+                ErrorPercentage = 90,
+                PercentageType = PercentageType.PercentageUsed,
+            };
+
+            var request = MetricQueryRequest.Create(widget);
+
+            await new LogicalDriveUsageQuery().Handle(request, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(State.Ok, widget.State);
+        }
+
+        [TestMethod]
+        public async Task LogicalDriveUsage_PercentageUsed_Failed_Test()
+        {
+            var drive = DriveInfo.GetDrives().First();
+
+            var widget = new LogicalDriveUsage
+            {
+                Drive = drive.Name,
+                ErrorPercentage = 0,
+                PercentageType = PercentageType.PercentageUsed,
+            };
+
+            var request = MetricQueryRequest.Create(widget);
+
+            await new LogicalDriveUsageQuery().Handle(request, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(State.Failed, widget.State);
+        }
+
+        [TestMethod]
+        public async Task LogicalDriveUsage_PercentageRemaining_Test()
+        {
+            var drive = DriveInfo.GetDrives().First();
+
+            var widget = new LogicalDriveUsage
+            {
+                Drive = drive.Name,
+                ErrorPercentage = 0,
+                PercentageType = PercentageType.PercentageRemaining,
+            };
+
+            var request = MetricQueryRequest.Create(widget);
+
+            await new LogicalDriveUsageQuery().Handle(request, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(State.Ok, widget.State);
+        }
+
+        [TestMethod]
+        public async Task LogicalDriveUsage_PercentageRemaining_Failed_Test()
+        {
+            var drive = DriveInfo.GetDrives().First();
+
+            var widget = new LogicalDriveUsage
+            {
+                Drive = drive.Name,
+                ErrorPercentage = 100,
+                PercentageType = PercentageType.PercentageRemaining,
+            };
+
+            var request = MetricQueryRequest.Create(widget);
+
+            await new LogicalDriveUsageQuery().Handle(request, CancellationToken.None).ConfigureAwait(false);
 
             Assert.AreEqual(State.Failed, widget.State);
         }

--- a/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
+++ b/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -106,6 +106,10 @@
     <Compile Include="Widgets\HealthChecks\SqlServer\Connection\SqlServerHealthCheck.cs" />
     <Compile Include="Widgets\SystemInformation\FileSystem\FolderExists.cs" />
     <Compile Include="Widgets\SystemInformation\FileSystem\FileExists.cs" />
+    <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\DriveInformation.cs" />
+    <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\LogicalDriveUsage.cs" />
+    <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\LogicalDriveUsageQuery.cs" />
+    <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\PercentageType.cs" />
     <Compile Include="Widgets\SystemInformation\PageFile\PageFileUsage.cs" />
     <Compile Include="Widgets\SystemInformation\PageFile\PageFileUsageQuery.cs" />
     <Compile Include="Widgets\SystemInformation\ProcessCount\ProcessCount.cs" />

--- a/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
+++ b/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -231,7 +231,7 @@
     <Copy SourceFiles="@(NuGetPackages)" DestinationFolder="C:\nuget" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Debug (
+    <PostBuildEvent>if $(ConfigurationName) == Local (
 echo copying binaries
 xcopy $(TargetDir)AnyStatus.Plugins.dll "C:\Repos\AnyStatus\App\src\AnyStatus.Desktop\bin\Debug" /y
 echo binaries copied

--- a/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
+++ b/src/AnyStatus.Plugins/AnyStatus.Plugins.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\LogicalDriveUsage.cs" />
     <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\LogicalDriveUsageQuery.cs" />
     <Compile Include="Widgets\SystemInformation\Logical Drives\Usage\PercentageType.cs" />
+    <Compile Include="Widgets\SystemInformation\Logical Drives\LogicalDriveNameEditor.cs" />
     <Compile Include="Widgets\SystemInformation\PageFile\PageFileUsage.cs" />
     <Compile Include="Widgets\SystemInformation\PageFile\PageFileUsageQuery.cs" />
     <Compile Include="Widgets\SystemInformation\ProcessCount\ProcessCount.cs" />

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/LogicalDriveNameEditor.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/LogicalDriveNameEditor.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using Xceed.Wpf.Toolkit.PropertyGrid;
+using Xceed.Wpf.Toolkit.PropertyGrid.Editors;
+
+namespace AnyStatus
+{
+    public class LogicalDriveNameEditor : ITypeEditor
+    {
+        private const string Key = "Key";
+        private const string Value = "Value";
+
+        [ExcludeFromCodeCoverage]
+        public FrameworkElement ResolveEditor(PropertyItem propertyItem)
+        {
+            return CreateElement(propertyItem, propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay);
+        }
+
+        public static FrameworkElement CreateElement(object bindingSource, BindingMode bindingMode)
+        {
+            var drives = Directory.GetLogicalDrives()
+                .Select(drive => new KeyValuePair<string, string>(drive, drive))
+                .ToList();
+
+            var comboBox = new ComboBox
+            {
+                ItemsSource = drives,
+                DisplayMemberPath = Key,
+                SelectedValuePath = Value,
+            };
+
+            var binding = new Binding(Value)
+            {
+                Source = bindingSource,
+                ValidatesOnExceptions = true,
+                ValidatesOnDataErrors = true,
+                Mode = bindingMode
+            };
+
+            BindingOperations.SetBinding(comboBox, Selector.SelectedValueProperty, binding);
+
+            return comboBox;
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace AnyStatus
@@ -8,8 +9,14 @@ namespace AnyStatus
         private const string Kernel32 = "kernel32.dll";
         private const int GigabyteFactor = 1024 * 1024 * 1024;
 
+        private DriveInformation()
+        {
+        }
+
         public string Drive { get; private set; }
+
         public ulong TotalNumberOfFreeBytes { get; private set; }
+
         public ulong TotalNumberOfBytes { get; private set; }
 
         public int TotalNumberOfGigabytes
@@ -37,11 +44,6 @@ namespace AnyStatus
             get => (int)Math.Round(((TotalNumberOfBytes - TotalNumberOfFreeBytes) / (double)TotalNumberOfBytes) * 100);
         }
 
-        private DriveInformation()
-        {
-
-        }
-
         [DllImport(Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool GetDiskFreeSpaceEx([In] string directoryName,
@@ -53,10 +55,10 @@ namespace AnyStatus
         {
             if (!GetDiskFreeSpaceEx(drive, out _, out ulong totalNumberOfBytes, out ulong totalNumberOfFreeBytes))
             {
-                return null;
+                throw new DriveNotFoundException($"An error occurred while getting drive information. No drive can be found with the specified name: {drive}.");
             }
 
-            return new DriveInformation()
+            return new DriveInformation
             {
                 Drive = drive,
                 TotalNumberOfBytes = totalNumberOfBytes,

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace AnyStatus
+{
+    public class DriveInformation
+    {
+        private const string Kernel32 = "kernel32.dll";
+
+        [DllImport(Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetDiskFreeSpaceEx([In] string directoryName,
+                                                 [Out] out ulong freeBytesAvailable,
+                                                 [Out] out ulong totalNumberOfBytes,
+                                                 [Out] out ulong totalNumberOfFreeBytes);
+
+        public static int GetDriveAvailablePercentage(string drive)
+        {
+            ulong totalNumberOfFreeBytes;
+            ulong totalNumberOfBytes;
+
+            if (!GetDiskFreeSpaceEx(drive, out _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
+            {
+                return -1;
+            }
+
+            return (int)Math.Round((totalNumberOfFreeBytes / (double)totalNumberOfBytes) * 100);
+        }
+
+        public static int GetDriveUsedPercentage(string drive)
+        {
+            ulong totalNumberOfFreeBytes;
+            ulong totalNumberOfBytes;
+
+            if (!GetDiskFreeSpaceEx(drive, out ulong _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
+            {
+                return -1;
+            }
+
+            ulong totalNumberOfUsedBytes = totalNumberOfBytes - totalNumberOfFreeBytes;
+
+            return (int)Math.Round((totalNumberOfUsedBytes / (double)totalNumberOfBytes) * 100);
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
@@ -6,6 +6,41 @@ namespace AnyStatus
     public class DriveInformation
     {
         private const string Kernel32 = "kernel32.dll";
+        private const int GigabyteFactor = 1024 * 1024 * 1024;
+
+        public string Drive { get; private set; }
+        public ulong TotalNumberOfFreeBytes { get; private set; }
+        public ulong TotalNumberOfBytes { get; private set; }
+
+        public int TotalNumberOfGigabytes
+        {
+            get => (int)Math.Round((double)TotalNumberOfBytes / GigabyteFactor);
+        }
+
+        public int TotalNumberOfFreeGigabytes
+        {
+            get => (int)Math.Round((double)TotalNumberOfFreeBytes / GigabyteFactor);
+        }
+
+        public int TotalNumberOfUsedGigabytes
+        {
+            get => (int)Math.Round((double)(TotalNumberOfBytes - TotalNumberOfFreeBytes) / GigabyteFactor);
+        }
+
+        public int AvailablePercentage
+        {
+            get => (int)Math.Round((TotalNumberOfFreeBytes / (double)TotalNumberOfBytes) * 100);
+        }
+
+        public int UsedPercentage
+        {
+            get => (int)Math.Round(((TotalNumberOfBytes - TotalNumberOfFreeBytes) / (double)TotalNumberOfBytes) * 100);
+        }
+
+        private DriveInformation()
+        {
+
+        }
 
         [DllImport(Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -14,32 +49,19 @@ namespace AnyStatus
                                                       [Out] out ulong totalNumberOfBytes,
                                                       [Out] out ulong totalNumberOfFreeBytes);
 
-        public static int GetDriveAvailablePercentage(string drive)
+        public static DriveInformation ReadDrive(string drive)
         {
-            ulong totalNumberOfFreeBytes;
-            ulong totalNumberOfBytes;
-
-            if (!GetDiskFreeSpaceEx(drive, out _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
+            if (!GetDiskFreeSpaceEx(drive, out _, out ulong totalNumberOfBytes, out ulong totalNumberOfFreeBytes))
             {
-                return -1;
+                return null;
             }
 
-            return (int)Math.Round((totalNumberOfFreeBytes / (double)totalNumberOfBytes) * 100);
-        }
-
-        public static int GetDriveUsedPercentage(string drive)
-        {
-            ulong totalNumberOfFreeBytes;
-            ulong totalNumberOfBytes;
-
-            if (!GetDiskFreeSpaceEx(drive, out _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
+            return new DriveInformation()
             {
-                return -1;
-            }
-
-            ulong totalNumberOfUsedBytes = totalNumberOfBytes - totalNumberOfFreeBytes;
-
-            return (int)Math.Round((totalNumberOfUsedBytes / (double)totalNumberOfBytes) * 100);
+                Drive = drive,
+                TotalNumberOfBytes = totalNumberOfBytes,
+                TotalNumberOfFreeBytes = totalNumberOfFreeBytes
+            };
         }
     }
 }

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/DriveInformation.cs
@@ -10,9 +10,9 @@ namespace AnyStatus
         [DllImport(Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool GetDiskFreeSpaceEx([In] string directoryName,
-                                                 [Out] out ulong freeBytesAvailable,
-                                                 [Out] out ulong totalNumberOfBytes,
-                                                 [Out] out ulong totalNumberOfFreeBytes);
+                                                      [Out] out ulong freeBytesAvailable,
+                                                      [Out] out ulong totalNumberOfBytes,
+                                                      [Out] out ulong totalNumberOfFreeBytes);
 
         public static int GetDriveAvailablePercentage(string drive)
         {
@@ -32,7 +32,7 @@ namespace AnyStatus
             ulong totalNumberOfFreeBytes;
             ulong totalNumberOfBytes;
 
-            if (!GetDiskFreeSpaceEx(drive, out ulong _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
+            if (!GetDiskFreeSpaceEx(drive, out _, out totalNumberOfBytes, out totalNumberOfFreeBytes))
             {
                 return -1;
             }

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
@@ -18,9 +18,11 @@ namespace AnyStatus
             Units = IntervalUnits.Seconds;
         }
 
+        [Required]
         [Category("Process CPU Usage")]
         [DisplayName("Drive")]
         [Description("The logical drive")]
+        [Editor(typeof(LogicalDriveNameEditor), typeof(LogicalDriveNameEditor))]
         public string Drive { get; set; }
 
         [Required]

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
@@ -1,0 +1,49 @@
+﻿using AnyStatus.API;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Xml.Serialization;
+
+namespace AnyStatus
+{
+    [DisplayName("Logical Drive Usage")]
+    [DisplayColumn("System Information")]
+    [Description("Shows the percentage of used space in a logical drive")]
+    public class LogicalDriveUsage : Metric, ISchedulable, IReportProgress
+    {
+        public LogicalDriveUsage()
+        {
+            Name = "Logical Drive Usage";
+            Symbol = "%";
+            Interval = 10;
+            Units = IntervalUnits.Seconds;
+        }
+
+        [Category("Process CPU Usage")]
+        [DisplayName("Drive")]
+        [Description("The logical drive")]
+        public string Drive { get; set; }
+
+        [Required]
+        [Category("Process CPU Usage")]
+        [DisplayName("Percentage Type")]
+        public PercentageType PercentageType { get; set; }
+
+        [Category("Process CPU Usage")]
+        [DisplayName("Show progress bar")]
+        [Description("Should the status show a bar displaying how full the drive is?")]
+        public bool ShowProgress { get; set; } = true;
+
+        [XmlIgnore]
+        [Browsable(false)]
+        public int Progress
+        {
+            get => (Value is int) ? (int)Value : -1;
+            set
+            {
+                Value = value;
+
+                OnPropertyChanged();
+            }
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsage.cs
@@ -19,21 +19,26 @@ namespace AnyStatus
         }
 
         [Required]
-        [Category("Process CPU Usage")]
+        [Category("Logical Drive Usage")]
         [DisplayName("Drive")]
         [Description("The logical drive")]
         [Editor(typeof(LogicalDriveNameEditor), typeof(LogicalDriveNameEditor))]
         public string Drive { get; set; }
 
         [Required]
-        [Category("Process CPU Usage")]
+        [Category("Logical Drive Usage")]
         [DisplayName("Percentage Type")]
         public PercentageType PercentageType { get; set; }
 
-        [Category("Process CPU Usage")]
+        [Category("Logical Drive Usage")]
         [DisplayName("Show progress bar")]
         [Description("Should the status show a bar displaying how full the drive is?")]
         public bool ShowProgress { get; set; } = true;
+
+        [Category("Logical Drive Usage")]
+        [DisplayName("Error percentage")]
+        [Description("At what percentage should this drive error?")]
+        public int ErrorPercentage { get; set; }
 
         [XmlIgnore]
         [Browsable(false)]

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -1,0 +1,34 @@
+﻿using AnyStatus.API;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AnyStatus
+{
+    public class LogicalDriveUsageQuery : IMetricQuery<LogicalDriveUsage>
+    {
+        [DebuggerStepThrough]
+        public async Task Handle(MetricQueryRequest<LogicalDriveUsage> request, CancellationToken cancellationToken)
+        {
+            request.DataContext.Progress = GetDriveUsageAsync(request.DataContext.Drive, request.DataContext.PercentageType);
+
+            request.DataContext.State = State.Ok;
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        private int GetDriveUsageAsync(string drive, PercentageType percentageType)
+        {
+            switch (percentageType)
+            {
+                case PercentageType.PercentageUsed:
+                    return DriveInformation.GetDriveUsedPercentage(drive);
+                case PercentageType.PercentageRemaining:
+                    return DriveInformation.GetDriveAvailablePercentage(drive);
+                default:
+                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+            }
+        }
+    }
+}

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -8,24 +8,43 @@ namespace AnyStatus
 {
     public class LogicalDriveUsageQuery : IMetricQuery<LogicalDriveUsage>
     {
+        private static readonly string NL = Environment.NewLine;
+
         [DebuggerStepThrough]
         public async Task Handle(MetricQueryRequest<LogicalDriveUsage> request, CancellationToken cancellationToken)
         {
-            request.DataContext.Progress = GetDriveUsageAsync(request.DataContext.Drive, request.DataContext.PercentageType);
+            DriveInformation driveInformation = DriveInformation.ReadDrive(request.DataContext.Drive);
 
+            request.DataContext.Progress = GetDrivePercentage(driveInformation, request.DataContext.PercentageType);
+            request.DataContext.Message = GetDriveMessage(driveInformation, request.DataContext.PercentageType);
             request.DataContext.State = State.Ok;
 
             await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        private int GetDriveUsageAsync(string drive, PercentageType percentageType)
+        private int GetDrivePercentage(DriveInformation driveInformation, PercentageType percentageType)
         {
             switch (percentageType)
             {
                 case PercentageType.PercentageUsed:
-                    return DriveInformation.GetDriveUsedPercentage(drive);
+                    return driveInformation.UsedPercentage;
                 case PercentageType.PercentageRemaining:
-                    return DriveInformation.GetDriveAvailablePercentage(drive);
+                    return driveInformation.AvailablePercentage;
+                default:
+                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+            }
+        }
+
+        private string GetDriveMessage(DriveInformation driveInformation, PercentageType percentageType)
+        {
+            switch (percentageType)
+            {
+                case PercentageType.PercentageUsed:
+                    return $"{driveInformation.Drive} - {driveInformation.UsedPercentage}%{NL}" +
+                           $"{driveInformation.TotalNumberOfUsedGigabytes}GB used out of {driveInformation.TotalNumberOfGigabytes}GB";
+                case PercentageType.PercentageRemaining:
+                    return $"{driveInformation.Drive} - {driveInformation.AvailablePercentage}%{NL}" +
+                           $"{driveInformation.TotalNumberOfFreeGigabytes}GB available out of {driveInformation.TotalNumberOfGigabytes}GB";
                 default:
                     throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
             }

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -17,7 +17,7 @@ namespace AnyStatus
 
             request.DataContext.Progress = GetDrivePercentage(driveInformation, request.DataContext.PercentageType);
             request.DataContext.Message = GetDriveMessage(driveInformation, request.DataContext.PercentageType);
-            request.DataContext.State = State.Ok;
+            request.DataContext.State = GetDriveState(driveInformation, request.DataContext.PercentageType, request.DataContext.ErrorPercentage);
 
             await Task.CompletedTask.ConfigureAwait(false);
         }
@@ -45,6 +45,19 @@ namespace AnyStatus
                 case PercentageType.PercentageRemaining:
                     return $"{driveInformation.Drive} - {driveInformation.AvailablePercentage}%{NL}" +
                            $"{driveInformation.TotalNumberOfFreeGigabytes}GB available out of {driveInformation.TotalNumberOfGigabytes}GB";
+                default:
+                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+            }
+        }
+
+        private State GetDriveState(DriveInformation driveInformation, PercentageType percentageType, int errorPercentage)
+        {
+            switch (percentageType)
+            {
+                case PercentageType.PercentageUsed:
+                    return driveInformation.UsedPercentage >= errorPercentage ? State.Error : State.Ok;
+                case PercentageType.PercentageRemaining:
+                    return driveInformation.AvailablePercentage <= errorPercentage ? State.Error : State.Ok;
                 default:
                     throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
             }

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -20,10 +20,12 @@ namespace AnyStatus
             {
                 case PercentageType.PercentageUsed:
                     return driveInformation.UsedPercentage;
+
                 case PercentageType.PercentageRemaining:
                     return driveInformation.AvailablePercentage;
+
                 default:
-                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+                    throw new NotImplementedException($"Percentage type \"{percentageType}\" is not supported");
             }
         }
 
@@ -33,12 +35,14 @@ namespace AnyStatus
             {
                 case PercentageType.PercentageUsed:
                     return $"{driveInformation.Drive} - {driveInformation.UsedPercentage}%{Environment.NewLine}" +
-                           $"{driveInformation.TotalNumberOfUsedGigabytes}GB used out of {driveInformation.TotalNumberOfGigabytes}GB";
+                           $"{driveInformation.TotalNumberOfUsedGigabytes} GB used out of {driveInformation.TotalNumberOfGigabytes} GB";
+
                 case PercentageType.PercentageRemaining:
                     return $"{driveInformation.Drive} - {driveInformation.AvailablePercentage}%{Environment.NewLine}" +
-                           $"{driveInformation.TotalNumberOfFreeGigabytes}GB available out of {driveInformation.TotalNumberOfGigabytes}GB";
+                           $"{driveInformation.TotalNumberOfFreeGigabytes} GB available out of {driveInformation.TotalNumberOfGigabytes} GB";
+
                 default:
-                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+                    throw new NotImplementedException($"Percentage type \"{percentageType}\" is not supported.");
             }
         }
 
@@ -48,10 +52,12 @@ namespace AnyStatus
             {
                 case PercentageType.PercentageUsed:
                     return driveInformation.UsedPercentage >= errorPercentage ? State.Error : State.Ok;
+
                 case PercentageType.PercentageRemaining:
                     return driveInformation.AvailablePercentage <= errorPercentage ? State.Error : State.Ok;
+
                 default:
-                    throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");
+                    throw new NotImplementedException($"Percentage type \"{percentageType}\" is not supported.");
             }
         }
     }

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -51,10 +51,10 @@ namespace AnyStatus
             switch (percentageType)
             {
                 case PercentageType.PercentageUsed:
-                    return driveInformation.UsedPercentage >= errorPercentage ? State.Error : State.Ok;
+                    return driveInformation.UsedPercentage >= errorPercentage ? State.Failed : State.Ok;
 
                 case PercentageType.PercentageRemaining:
-                    return driveInformation.AvailablePercentage <= errorPercentage ? State.Error : State.Ok;
+                    return driveInformation.AvailablePercentage <= errorPercentage ? State.Failed : State.Ok;
 
                 default:
                     throw new NotImplementedException($"Percentage type \"{percentageType}\" is not supported.");

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/LogicalDriveUsageQuery.cs
@@ -1,25 +1,17 @@
 ﻿using AnyStatus.API;
 using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace AnyStatus
 {
-    public class LogicalDriveUsageQuery : IMetricQuery<LogicalDriveUsage>
+    public class LogicalDriveUsageQuery : RequestHandler<MetricQueryRequest<LogicalDriveUsage>>
     {
-        private static readonly string NL = Environment.NewLine;
-
-        [DebuggerStepThrough]
-        public async Task Handle(MetricQueryRequest<LogicalDriveUsage> request, CancellationToken cancellationToken)
+        protected override void HandleCore(MetricQueryRequest<LogicalDriveUsage> request)
         {
-            DriveInformation driveInformation = DriveInformation.ReadDrive(request.DataContext.Drive);
+            var driveInformation = DriveInformation.ReadDrive(request.DataContext.Drive);
 
             request.DataContext.Progress = GetDrivePercentage(driveInformation, request.DataContext.PercentageType);
             request.DataContext.Message = GetDriveMessage(driveInformation, request.DataContext.PercentageType);
             request.DataContext.State = GetDriveState(driveInformation, request.DataContext.PercentageType, request.DataContext.ErrorPercentage);
-
-            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         private int GetDrivePercentage(DriveInformation driveInformation, PercentageType percentageType)
@@ -40,10 +32,10 @@ namespace AnyStatus
             switch (percentageType)
             {
                 case PercentageType.PercentageUsed:
-                    return $"{driveInformation.Drive} - {driveInformation.UsedPercentage}%{NL}" +
+                    return $"{driveInformation.Drive} - {driveInformation.UsedPercentage}%{Environment.NewLine}" +
                            $"{driveInformation.TotalNumberOfUsedGigabytes}GB used out of {driveInformation.TotalNumberOfGigabytes}GB";
                 case PercentageType.PercentageRemaining:
-                    return $"{driveInformation.Drive} - {driveInformation.AvailablePercentage}%{NL}" +
+                    return $"{driveInformation.Drive} - {driveInformation.AvailablePercentage}%{Environment.NewLine}" +
                            $"{driveInformation.TotalNumberOfFreeGigabytes}GB available out of {driveInformation.TotalNumberOfGigabytes}GB";
                 default:
                     throw new NotImplementedException($"Not implemented the percentage type of [{percentageType}]");

--- a/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/PercentageType.cs
+++ b/src/AnyStatus.Plugins/Widgets/SystemInformation/Logical Drives/Usage/PercentageType.cs
@@ -1,0 +1,8 @@
+﻿namespace AnyStatus
+{
+    public enum PercentageType
+    {
+        PercentageUsed,
+        PercentageRemaining
+    }
+}


### PR DESCRIPTION
Created a plugin to monitor the percentage of a logical drive for issue AnyStatus/Support#137

- Through config it can do both percentage used and percentage available.
- It sends out notifications when the drive reaches a specific percentage set by the user.
- Has a custom tooltip
- Lets the user pick a drive from a drop-down

No unit tests written yet but I'd like to see what you think of it - if it's good then I can add some before you merge this pull request?