### PR TITLE
Updated weather widget to parse and display correct temperature values

### DIFF
--- a/src/AnyStatus.Plugins/Widgets/Metrics/Weather/CurrentWeatherMetricQuery.cs
+++ b/src/AnyStatus.Plugins/Widgets/Metrics/Weather/CurrentWeatherMetricQuery.cs
@@ -18,7 +18,7 @@ namespace AnyStatus
 
             var response = await restClient.ExecuteTaskAsync<CurrentWeather>(restRequest, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessful && double.TryParse(response.Data.Main["temp"], out var temp))
+            if (response.IsSuccessful && double.TryParse(response.Data.Main["temp"], System.Globalization.NumberStyles.Number, new System.Globalization.CultureInfo("en-US"), out var temp))
             {
                 char symbol;
 


### PR DESCRIPTION
Hi, I updated weather widget to parse and display correct temperature values on non-english machines. On my german laptop the temp value "297.24" by openweathermap was parsed as "29724" and therefore displayed wrong values.