### PR TITLE
Update Teamcity plugin to use Bearer auth

### DIFF
--- a/src/AnyStatus.Plugins/Widgets/TeamCity/Build/TeamCityBuild.cs
+++ b/src/AnyStatus.Plugins/Widgets/TeamCity/Build/TeamCityBuild.cs
@@ -78,25 +78,17 @@ namespace AnyStatus
             {
                 _guestUser = value;
 
-                SetPropertyVisibility(nameof(UserName), !_guestUser);
-                SetPropertyVisibility(nameof(Password), !_guestUser);
+                SetPropertyVisibility(nameof(Token), !_guestUser);
             }
         }
 
         [Browsable(true)]
         [PropertyOrder(60)]
         [Category(Category)]
-        [DisplayName("User name")]
-        [Description("Optional.")]
-        public string UserName { get; set; }
-
-        [Browsable(true)]
-        [PropertyOrder(70)]
-        [Category(Category)]
         [PasswordPropertyText(true)]
         [Description("Optional.")]
         [Editor(typeof(PasswordEditor), typeof(PasswordEditor))]
-        public string Password { get; set; }
+        public string Token { get; set; }
 
         public override Notification CreateNotification()
         {

--- a/src/AnyStatus.Plugins/Widgets/TeamCity/Client/TeamCityConnection.cs
+++ b/src/AnyStatus.Plugins/Widgets/TeamCity/Client/TeamCityConnection.cs
@@ -12,10 +12,7 @@
         public string Url { get; set; }
 
         public bool GuestUser { get; set; }
-
-        public string UserName { get; set; }
-
-        public string Password { get; set; }
+        public string Token { get; set; }
 
         public bool IgnoreSslErrors { get; set; }
     }


### PR DESCRIPTION
Currently the Teamcity plugin requires the input of a password and username to be able to connect to Teamcity. However, a Bearer token is a safer option.

I've removed the username and password option completely. I can re-add them if you want to keep the backwards-compatibility.

